### PR TITLE
Feature/delete all

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Easy-DI is a simple yet powerful Python library for dependency injection. It hel
 - **Strict enforcement of string-based dependency IDs**
 - **Grouped dependency injection** for better organization
 - **Supports wildcard injection (`group.*`) to inject all dependencies from a group as separate elements**
+- **Supports bulk unregistration using wildcard patterns (e.g., `*`, `group.*`)**
 - **Full compatibility with Python's type hints** for type safety
 
 ## Installation 💻📦⚙️
@@ -96,6 +97,18 @@ def app_settings(deps):
 print(app_settings())  # Output: "Host: localhost, Port: 8080, Debug: True"
 ```
 
+### Bulk Unregistration with Wildcards ❌🧹🚫
+
+You can unregister multiple dependencies at once using wildcard patterns:
+
+```python
+from easy_di import BaseInjector, GroupInjector
+
+BaseInjector.unregister("*")  # Unregister all dependencies in BaseInjector
+GroupInjector.unregister_dependency("test.*")  # Unregister all dependencies in group "test"
+GroupInjector.unregister_dependency_group("*")  # Unregister all dependency groups and their dependencies
+```
+
 ## API Reference 📚🔍🛠️
 
 ### `BaseInjector` ⚙️🔄📌
@@ -107,7 +120,7 @@ Decorator that injects a registered dependency into a function.
 Registers a dependency using a string ID.
 
 #### `BaseInjector.unregister(dependency_id: str) -> None`
-Unregisters a dependency by its ID.
+Unregisters a dependency by its ID. Supports `"*"` to unregister all.
 
 ---
 
@@ -123,10 +136,10 @@ Registers a dependency group containing multiple dependencies.
 Registers a dependency inside an existing group.
 
 #### `GroupInjector.unregister_dependency(dependency_id: str, group_id: Optional[str] = None) -> None`
-Unregisters a specific dependency from a group.
+Unregisters a specific dependency from a group. Supports wildcards (e.g., `"group.*"`).
 
 #### `GroupInjector.unregister_dependency_group(group_id: str) -> None`
-Unregisters an entire dependency group.
+Unregisters an entire dependency group. Supports `"*"` to unregister all groups.
 
 ## Development & Configuration 🛠️💡🔧
 

--- a/src/easy_di/base_injector.py
+++ b/src/easy_di/base_injector.py
@@ -78,12 +78,12 @@ class BaseInjector:
         :raises TypeError: If the dependency ID is not a string.
         :raises DependencyRegisteredError: If the dependency ID is already registered.
         """
+        if dependency_id == "*":
+            raise ValueError("Dependency ID cannot be '*'")
         if not isinstance(dependency_id, str):
             raise TypeError("Dependency ID must be a string")
         if dependency_id in cls._registered_dependencies:
             raise DependencyRegisteredError(dependency_id)
-        if dependency_id == "*":
-            raise ValueError("Dependency ID cannot be '*'")
         cls._registered_dependencies[dependency_id] = dependency
 
 

--- a/src/easy_di/base_injector.py
+++ b/src/easy_di/base_injector.py
@@ -76,6 +76,7 @@ class BaseInjector:
         :param dependency_id: The unique identifier for the dependency.
         :param dependency: The actual dependency (e.g., object, class, function).
         :raises TypeError: If the dependency ID is not a string.
+        :raises ValueError: If the dependency ID is '*'.
         :raises DependencyRegisteredError: If the dependency ID is already registered.
         """
         if dependency_id == "*":

--- a/src/easy_di/base_injector.py
+++ b/src/easy_di/base_injector.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import functools
 import sys
 from typing import Any, Callable, ClassVar, Dict, TypeVar
+from warnings import warn
 
 if sys.version_info >= (3, 10):
     from typing import Concatenate, ParamSpec
@@ -81,6 +82,8 @@ class BaseInjector:
             raise TypeError("Dependency ID must be a string")
         if dependency_id in cls._registered_dependencies:
             raise DependencyRegisteredError(dependency_id)
+        if dependency_id == "*":
+            raise ValueError("Dependency ID cannot be '*'")
         cls._registered_dependencies[dependency_id] = dependency
 
 
@@ -91,6 +94,10 @@ class BaseInjector:
         :param dependency_id: The unique identifier of the dependency to remove.
         :raises DependencyNotRegisteredError: If the dependency ID is not registered.
         """
+        if dependency_id == "*":
+            cls._registered_dependencies.clear()
+            warn("Deleted all registered dependencies.")
+            return
         if dependency_id not in cls._registered_dependencies:
             raise DependencyNotRegisteredError(dependency_id)
         cls._registered_dependencies.pop(dependency_id)

--- a/src/easy_di/group_injector.py
+++ b/src/easy_di/group_injector.py
@@ -93,6 +93,7 @@ class GroupInjector:
         :param dependency: The actual dependency (e.g., object, class, function).
         :param group_id: The group where the dependency should be registered.
         :raises TypeError: If dependency_id or group_id is not a string.
+        :raises ValueError: If the dependency ID is '*'.
         :raises DependencyGroupNotRegisteredError: If the specified group is not registered.
         :raises DependencyRegisteredError: If the dependency ID is already registered in the group.
         :raises DependencyFormatError: If the dependency ID is not contain group and group_id is not specified.
@@ -145,7 +146,7 @@ class GroupInjector:
         :param group_id: The unique identifier for the group.
         :param dependencies: Key-value pairs representing dependency IDs and their values.
         :raises TypeError: If the group or dependency ID is not a string.
-        :raises ValueError: If the group ID contains dot.
+        :raises ValueError: If the group ID contains dot or dependency or group ID is '*'.
         :raises DependencyGroupRegisteredError: If the group ID is already registered.
         """
         if not isinstance(group_id, str):

--- a/src/easy_di/group_injector.py
+++ b/src/easy_di/group_injector.py
@@ -125,12 +125,12 @@ class GroupInjector:
         dependency_id, group_id = cls._parse_dependency_and_group(
             dependency_id,
             group_id)
-        if dependency_id == "*":
-            cls._registered_dependencies.clear()
-            warn("Deleted all registered dependencies.")
-            return
         if group_id not in cls._registered_dependencies:
             raise DependencyGroupNotRegisteredError(group_id)
+        if dependency_id == "*":
+            cls._registered_dependencies[group_id].clear()
+            warn("Deleted all registered dependencies.")
+            return
         if dependency_id not in cls._registered_dependencies[group_id]:
             raise DependencyNotRegisteredError(dependency_id)
         cls._registered_dependencies[group_id].pop(dependency_id)

--- a/src/easy_di/group_injector.py
+++ b/src/easy_di/group_injector.py
@@ -104,6 +104,8 @@ class GroupInjector:
             raise DependencyGroupNotRegisteredError(group_id)
         if dependency_id in cls._registered_dependencies[group_id]:
             raise DependencyRegisteredError(dependency_id)
+        if dependency_id == "*":
+            raise ValueError("Dependency ID cannot be '*'")
         cls._registered_dependencies[group_id][dependency_id] = dependency
 
     @classmethod
@@ -123,6 +125,10 @@ class GroupInjector:
         dependency_id, group_id = cls._parse_dependency_and_group(
             dependency_id,
             group_id)
+        if dependency_id == "*":
+            cls._registered_dependencies.clear()
+            warn("Deleted all registered dependencies.")
+            return
         if group_id not in cls._registered_dependencies:
             raise DependencyGroupNotRegisteredError(group_id)
         if dependency_id not in cls._registered_dependencies[group_id]:
@@ -148,6 +154,8 @@ class GroupInjector:
             raise DependencyGroupRegisteredError(group_id)
         if "." in group_id:
             raise ValueError("Dependency group ID cannot contain dot")
+        if group_id == "*":
+            raise ValueError("Dependency group ID cannot be '*'")
         cls._registered_dependencies[group_id] = {}
         for dependency in dependencies:
             cls.register_dependency(dependency,
@@ -161,6 +169,10 @@ class GroupInjector:
         :param group_id: The unique identifier of the group to remove.
         :raises DependencyGroupNotRegisteredError: If the group ID is not registered.
         """
+        if group_id == "*":
+            cls._registered_dependencies.clear()
+            warn("Deleted all registered dependency groups.")
+            return
         if group_id not in cls._registered_dependencies:
             raise DependencyGroupNotRegisteredError(group_id)
         if len(cls._registered_dependencies[group_id]) != 0:

--- a/src/easy_di/group_injector.py
+++ b/src/easy_di/group_injector.py
@@ -100,12 +100,12 @@ class GroupInjector:
         dependency_id, group_id = cls._parse_dependency_and_group(
             dependency_id,
             group_id)
+        if dependency_id == "*":
+            raise ValueError("Dependency ID cannot be '*'")
         if group_id not in cls._registered_dependencies:
             raise DependencyGroupNotRegisteredError(group_id)
         if dependency_id in cls._registered_dependencies[group_id]:
             raise DependencyRegisteredError(dependency_id)
-        if dependency_id == "*":
-            raise ValueError("Dependency ID cannot be '*'")
         cls._registered_dependencies[group_id][dependency_id] = dependency
 
     @classmethod

--- a/tests/base_injector_test.py
+++ b/tests/base_injector_test.py
@@ -54,13 +54,22 @@ class BaseInjectorTest(unittest.TestCase):
         self.assertEqual(e.exception.dependency_id, "test")
 
     def test_register_incorrect_dependency_id(self) -> None:
-        with self.assertRaises(TypeError) as e:
+        with self.assertRaises(TypeError):
             easy_di.BaseInjector.register(123, "test")  # type: ignore
+        with self.assertRaises(ValueError):
+            easy_di.BaseInjector.register("*", "test")
 
     def test_unregister_when_dependency_not_registered(self) -> None:
         with self.assertRaises(DependencyNotRegisteredError) as e:
             easy_di.BaseInjector.unregister("test")
         self.assertEqual(e.exception.dependency_id, "test")
+
+    def test_unregister_all(self) -> None:
+        easy_di.BaseInjector.register("test", "test")
+        easy_di.BaseInjector.register("test2", "test2")
+        with self.assertWarns(Warning):
+            easy_di.BaseInjector.unregister("*")
+        self.assertDictEqual(easy_di.BaseInjector._registered_dependencies, {})
 
 
 if __name__ == "__main__":

--- a/tests/group_injector_test.py
+++ b/tests/group_injector_test.py
@@ -119,10 +119,14 @@ class GroupInjectorTest(unittest.TestCase):
     def test_register_dependency_incorrect_id(self) -> None:
         with self.assertRaises(TypeError):
             easy_di.GroupInjector.register_dependency(123, "test")  # type: ignore
+        with self.assertRaises(ValueError):
+            easy_di.GroupInjector.register_dependency("test.*", "test")
 
     def test_register_dependency_group_incorrect_id(self) -> None:
         with self.assertRaises(TypeError):
             easy_di.GroupInjector.register_dependency_group(123)  # type: ignore
+        with self.assertRaises(ValueError):
+            easy_di.GroupInjector.register_dependency_group("*")
 
     def test_register_registered_dependency_group(self) -> None:
         easy_di.GroupInjector.register_dependency_group("test")
@@ -157,6 +161,25 @@ class GroupInjectorTest(unittest.TestCase):
         with self.assertRaises(DependencyGroupNotRegisteredError) as e:
             easy_di.GroupInjector.unregister_dependency_group("test")
         self.assertEqual(e.exception.group_id, "test")
+
+    def test_unregister_all_dependencies_in_group(self) -> None:
+        easy_di.GroupInjector.register_dependency_group("test")
+        easy_di.GroupInjector.register_dependency("test.test", "test")
+        easy_di.GroupInjector.register_dependency("test.test2", "test2")
+        with self.assertWarns(Warning):
+            easy_di.GroupInjector.unregister_dependency("test.*")
+        self.assertDictEqual(easy_di.GroupInjector._registered_dependencies, {"test": {}})
+
+    def test_unregister_all_dependency_groups(self) -> None:
+        easy_di.GroupInjector.register_dependency_group("test")
+        easy_di.GroupInjector.register_dependency("test.test", "test")
+        easy_di.GroupInjector.register_dependency("test.test2", "test2")
+        easy_di.GroupInjector.register_dependency_group("test2")
+        easy_di.GroupInjector.register_dependency("test2.test", "test")
+        easy_di.GroupInjector.register_dependency("test2.test2", "test2")
+        with self.assertWarns(Warning):
+            easy_di.GroupInjector.unregister_dependency_group("*")
+        self.assertDictEqual(easy_di.GroupInjector._registered_dependencies, {})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I added avaibality to delete all deps and groups. Syntax:
```python
easy_di.BaseInjector.unregister("*")  # unregister all deps in BaseInjector
easy_di.GroupInjector.unregister_dependency("test.*")  # unregister all deps in group test
easy_di.GroupInjector.unregister_dependency_group("*")  # unregister all deps and groups in GroupInjector
```