### PR TITLE
Feature/autocreate group

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,10 @@ Decorator that injects dependencies from a registered group.
 #### `GroupInjector.register_dependency_group(group_id: str, **dependencies: Any) -> None`
 Registers a dependency group containing multiple dependencies.
 
-#### `GroupInjector.register_dependency(dependency_id: str, dependency: Any, group_id: Optional[str] = None) -> None`
+#### `GroupInjector.register_dependency(dependency_id: str, dependency: Any, group_id: Optional[str] = None, *, if_group_not_exists: Literal["error", "create"] = "error") -> None`
 Registers a dependency inside an existing group.
+
+if_group_not_exists: What to do when the group is not registered. Use "error" to raise an exception or "create" to automatically create the group.
 
 #### `GroupInjector.unregister_dependency(dependency_id: str, group_id: Optional[str] = None) -> None`
 Unregisters a specific dependency from a group. Supports wildcards (e.g., `"group.*"`).

--- a/src/easy_di/group_injector.py
+++ b/src/easy_di/group_injector.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import functools
 import sys
-from typing import Any, Callable, ClassVar, Dict, Optional, TypeVar
+from typing import Any, Callable, ClassVar, Dict, Optional, TypeVar, Literal
 
 if sys.version_info >= (3, 10):
     from typing import Concatenate, ParamSpec
@@ -86,7 +86,9 @@ class GroupInjector:
             cls,
             dependency_id: str,
             dependency: Any,
-            group_id: Optional[str] = None) -> None:
+            group_id: Optional[str] = None,
+            *,
+            if_group_not_exists: Literal["error", "create"] = "error") -> None:
         """Register a dependency within a specified group.
 
         :param dependency_id: The unique identifier for the dependency.
@@ -104,7 +106,10 @@ class GroupInjector:
         if dependency_id == "*":
             raise ValueError("Dependency ID cannot be '*'")
         if group_id not in cls._registered_dependencies:
-            raise DependencyGroupNotRegisteredError(group_id)
+            if if_group_not_exists == "error":
+                raise DependencyGroupNotRegisteredError(group_id)
+            if if_group_not_exists == "create":
+                cls.register_dependency_group(group_id)
         if dependency_id in cls._registered_dependencies[group_id]:
             raise DependencyRegisteredError(dependency_id)
         cls._registered_dependencies[group_id][dependency_id] = dependency

--- a/src/easy_di/group_injector.py
+++ b/src/easy_di/group_injector.py
@@ -94,6 +94,7 @@ class GroupInjector:
         :param dependency_id: The unique identifier for the dependency.
         :param dependency: The actual dependency (e.g., object, class, function).
         :param group_id: The group where the dependency should be registered.
+        :param if_group_not_exists: What to do when a dependency group is not registered.
         :raises TypeError: If dependency_id or group_id is not a string.
         :raises ValueError: If the dependency ID is '*'.
         :raises DependencyGroupNotRegisteredError: If the specified group is not registered.

--- a/src/easy_di/group_injector.py
+++ b/src/easy_di/group_injector.py
@@ -107,10 +107,10 @@ class GroupInjector:
         if dependency_id == "*":
             raise ValueError("Dependency ID cannot be '*'")
         if group_id not in cls._registered_dependencies:
-            if if_group_not_exists == "error":
-                raise DependencyGroupNotRegisteredError(group_id)
             if if_group_not_exists == "create":
                 cls.register_dependency_group(group_id)
+            else:
+                raise DependencyGroupNotRegisteredError(group_id)
         if dependency_id in cls._registered_dependencies[group_id]:
             raise DependencyRegisteredError(dependency_id)
         cls._registered_dependencies[group_id][dependency_id] = dependency

--- a/tests/group_injector_test.py
+++ b/tests/group_injector_test.py
@@ -181,6 +181,10 @@ class GroupInjectorTest(unittest.TestCase):
             easy_di.GroupInjector.unregister_dependency_group("*")
         self.assertDictEqual(easy_di.GroupInjector._registered_dependencies, {})
 
+    def test_autocreate_group(self) -> None:
+        easy_di.GroupInjector.register_dependency("test.test", "test", if_group_not_exists="create")
+        self.assertDictEqual(easy_di.GroupInjector._registered_dependencies, {"test": {"test": "test"}})
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Added possibble autocreate group if it doesn't exists. For this you need specify parameter  `if_group_not_exists` to `create`, when you register dependency.